### PR TITLE
Add command to run install script

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,13 @@ settings like this:
 
 ### How-to use ###
 
+#### Run the install script ####
+```bash
+$ wget -q -O- https://github.com/hugsy/gef/raw/master/scripts/gef-extras.sh | sh
+```
+
+#### Do it manually ####
+
 Start with cloning this repo:
 ```bash
 $ git clone https://github.com/hugsy/gef-extras


### PR DESCRIPTION
Under README.md, there are instructions to install gef-extras manually, while there is a command to use the install script in the gef repo.

It would be convenient if this repo also has it.