### PR TITLE
Add xref-telescope command

### DIFF
--- a/scripts/xref-telescope.py
+++ b/scripts/xref-telescope.py
@@ -1,0 +1,73 @@
+@register_command
+class XRefTelescopeCommand(SearchPatternCommand):
+    """Recursively search for cross-references to a pattern in memory"""
+
+    _cmdline_ = "xref-telescope"
+    _syntax_  = "{:s} PATTERN [depth]".format(_cmdline_)
+    _example_ = "\n{0:s} AAAAAAAA\n{0:s} 0x555555554000 15".format(_cmdline_)
+
+    def xref_telescope_(self, pattern, depth, tree_heading):
+        """Recursively search a pattern within the whole userland memory."""
+
+        if depth <= 0:
+            return
+
+        if is_hex(pattern):
+            if get_endian() == Elf.BIG_ENDIAN:
+                pattern = "".join(["\\x"+pattern[i:i+2] for i in range(2, len(pattern), 2)])
+            else:
+                pattern = "".join(["\\x"+pattern[i:i+2] for i in range(len(pattern)-2, 0, -2)])
+
+        locs = []
+        for section in get_process_maps():
+            if not section.permission & Permission.READ: continue
+            if section.path == "[vvar]": continue
+
+            start = section.page_start
+            end   = section.page_end - 1
+            old_section = None
+
+            locs += self.search_pattern_by_address(pattern, start, end)
+        if tree_heading == "":
+            gef_print(" .")
+        for i, loc in enumerate(locs):
+            addr_loc_start = lookup_address(loc[0])
+            path = addr_loc_start.section.path
+            perm = addr_loc_start.section.permission
+            if i == len(locs) - 1:
+                tree_suffix_pre  = " └──"
+                tree_suffix_post = "    "
+            else:
+                tree_suffix_pre  = " ├──"
+                tree_suffix_post = " │  "
+
+            gef_print('{} {:#x} {} {} "{}"'
+                        .format(tree_heading + tree_suffix_pre,
+                                loc[0], Color.blueify(path),
+                                perm, Color.pinkify(loc[2])))
+            self.xref_telescope_(hex(loc[0]), depth - 1,
+                                    tree_heading + tree_suffix_post)
+
+    def xref_telescope(self, pattern, depth):
+        self.xref_telescope_(pattern, depth, "")
+
+    @only_if_gdb_running
+    def do_invoke(self, argv):
+        argc = len(argv)
+        if argc < 1:
+            self.usage()
+            return
+
+        pattern = argv[0]
+        try:
+            depth = int(argv[1])
+        except (IndexError, ValueError):
+            depth = 3
+
+        info("Recursively searching '{:s}' in memory"
+             .format(Color.yellowify(pattern)))
+        self.xref_telescope(pattern, depth)
+
+
+if __name__ == "__main__":
+    register_external_command(XRefTelescopeCommand())


### PR DESCRIPTION
Add an `xref-telescope` command for recursively doing xrefs.

This implements the feature described [here](https://github.com/hugsy/gef/issues/425).

```
gef➤  xref-telescope /usr/bin/t
[+] Recursively searching '/usr/bin/t' in memory
 .
 ├── 0x7fffffffe434 [stack] rw- "/usr/bin/true"
 │   └── 0x7fffffffe148 [stack] rw- "\x34\xe4\xff\xff\xff\x7f[...]"
 ├── 0x7fffffffe50a [stack] rw- "/usr/bin/true"
 └── 0x7fffffffefea [stack] rw- "/usr/bin/true"
     └── 0x7fffffffe3e8 [stack] rw- "\xea\xef\xff\xff\xff\x7f[...]"
```