### PR TITLE
Add instructions to save config in README

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -42,6 +42,12 @@ a semi-colon:
 gef➤  gef config gef.extra_plugins_dir /path/to/dir1;/path/to/dir2
 ```
 
+And don't forget to save your settings.
+
+```
+gef➤ gef save
+```
+
 
 ### Contributions ###
 


### PR DESCRIPTION
The `gef save` command is missing in the installation instructions.