### PR TITLE
Fix x64 register display

### DIFF
--- a/scripts/windbg.py
+++ b/scripts/windbg.py
@@ -240,8 +240,8 @@ class WindbgRCommand(GenericCommand):
                 else: print()
 
     def arch_reg_width(self):
-        if get_arch().startswith("i386"): return 6
         if get_arch().startswith("i386:x86-64"): return 3
+        if get_arch().startswith("i386"): return 6
         if get_arch().startswith('aarch64'): return 4
         raise NotImplemented
 


### PR DESCRIPTION
Order matters when checking the register width for x86 and x64 as they both start with the same substring.