### PR TITLE
Stop relying on deprecated add_setting

### DIFF
--- a/scripts/ida_interact.py
+++ b/scripts/ida_interact.py
@@ -68,9 +68,9 @@ class RpycIdaCommand(GenericCommand):
     def __init__(self):
         global sess
         super(RpycIdaCommand, self).__init__(prefix=True)
-        self.add_setting("host", "127.0.0.1", "IDA host IP address")
-        self.add_setting("port", 18812, "IDA host port")
-        self.add_setting("sync_cursor", False, "Enable real-time $pc synchronisation")
+        self["host"] = ("127.0.0.1", "IDA host IP address")
+        self["port"] = (18812, "IDA host port")
+        self["sync_cursor"] = (False, "Enable real-time $pc synchronisation")
         self.last_hl_ea = -1
         return
 

--- a/scripts/retdec.py
+++ b/scripts/retdec.py
@@ -21,9 +21,9 @@ class RetDecCommand(GenericCommand):
 
     def __init__(self):
         super(RetDecCommand, self).__init__(complete=gdb.COMPLETE_SYMBOL)
-        self.add_setting("path", GEF_TEMP_DIR, "Path to store the decompiled code")
-        self.add_setting("retdec_path", "", "Path to the retdec installation")
-        self.add_setting("theme", "default", "Theme for pygments syntax highlighting")
+        self["path"] = (GEF_TEMP_DIR, "Path to store the decompiled code")
+        self["retdec_path"] = ("", "Path to the retdec installation")
+        self["theme"] = ("default", "Theme for pygments syntax highlighting")
         return
 
     @only_if_gdb_running

--- a/scripts/v8-dereference.py
+++ b/scripts/v8-dereference.py
@@ -47,7 +47,7 @@ class V8DereferenceCommand(GenericCommand):
 
     def __init__(self):
         super(V8DereferenceCommand, self).__init__(complete=gdb.COMPLETE_LOCATION)
-        self.add_setting("max_recursion", 7, "Maximum level of pointer recursion")
+        self["max_recursion"] = (7, "Maximum level of pointer recursion")
         gef_on_exit_hook(del_isolate_root)
         return
 


### PR DESCRIPTION
GEF deprecated the `add_setting` function, so migrate to using `self["setting"] = (value, description)`.
This gets rid of warnings when starting GDB.