### PR TITLE
fix `current-stack-frame` command

### DIFF
--- a/scripts/stack.py
+++ b/scripts/stack.py
@@ -39,7 +39,7 @@ class CurrentFrameStack(GenericCommand):
         else:
             gef_print(titlify("Stack bottom (lower address)"))
 
-        gef_print(results)
+        gef_print("\n".join(results))
 
         if should_stack_grow_down:
             gef_print(titlify("Stack bottom (lower address)"))


### PR DESCRIPTION
`current-stack-frame` passes a `list` to `gef_print()` which only takes a `str`
This PR simply joins the list into a string first.


But `current-stack-frame` seems to not work with the bottom frame (usually `main`).
It will always return the following error
```
[*] Cannot determine frame boundary, reason: no reason
```