### PR TITLE
Fix gdb error "read_memory not defined"

### DIFF
--- a/scripts/bincompare.py
+++ b/scripts/bincompare.py
@@ -69,7 +69,7 @@ class BincompareCommand(GenericCommand):
             return
 
         try:
-            memory_data = gdb.selected_inferior().read_memory(start_addr, size).tobytes()
+            memory_data = gef.memory.read(start_addr, size)
         except gdb.MemoryError:
             err("Cannot reach memory {:#x}".format(start_addr))
             return

--- a/scripts/bincompare.py
+++ b/scripts/bincompare.py
@@ -69,7 +69,7 @@ class BincompareCommand(GenericCommand):
             return
 
         try:
-            memory_data = read_memory(start_addr, size)
+            memory_data = gdb.selected_inferior().read_memory(start_addr, size).tobytes()
         except gdb.MemoryError:
             err("Cannot reach memory {:#x}".format(start_addr))
             return


### PR DESCRIPTION
Somehow the gef read_memory function does not exist anymore.
Therefore, I changed the function call to use the gdb's function
directly.