### PR TITLE
fix arm-m class definition

### DIFF
--- a/archs/arm-cortex-m.py
+++ b/archs/arm-cortex-m.py
@@ -11,7 +11,7 @@ Author: SWW13
 @register_architecture
 class ARM_M(ARM):
     arch = "ARM-M"
-    aliases = ("ARM-M", )
+    aliases = ("ARM-M", Elf.Abi.ARM)
 
     all_registers = ARM.all_registers[:-1] + ["$xpsr", ]
     flag_register = "$xpsr"


### PR DESCRIPTION
need Elf.Abi.ARM Type in alias, otherwise calls to `reset_architecture()`
produce below error:

```
[!] Command 'context' failed to execute properly, reason: unsupported operand type(s) for &: 'NoneType' and 'int'
```