### PR TITLE
fix ARM-M class definition

### DIFF
--- a/archs/arm-cortex-m.py
+++ b/archs/arm-cortex-m.py
@@ -11,7 +11,7 @@ Author: SWW13
 @register_architecture
 class ARM_M(ARM):
     arch = "ARM-M"
-    aliases = ("ARM-M", )
+    aliases = ("ARM-M", Elf.Abi.ARM)
 
     all_registers = ARM.all_registers[:-1] + ["$xpsr", ]
     flag_register = "$xpsr"


### PR DESCRIPTION
without the proper parameter for Elf.Abi, `reset_architecture` produces a
warning. This warnin is not only inconvenient, but does stop the debugger from
attaching automatically.

according to i.e. https://community.arm.com/support-forums/f/architectures-and-processors-forum/51867/how-can-i-know-if-an-elf-file-is-for-cortex-a-or-cortex-m
there is no different ABI code form ARM platforms. CPU Type would be needed to
make a proper distinction.