### PR TITLE
make sure the on-write function takes an argument

### DIFF
--- a/scripts/capstone.py
+++ b/scripts/capstone.py
@@ -108,7 +108,7 @@ class CapstoneDisassembleCommand(GenericCommand):
             int, int, Any], Generator[Instruction, None, None]]] = None
         return
 
-    def switch_disassembler(self) -> None:
+    def switch_disassembler(self, _) -> None:
         ctx = gef.gdb.commands["context"]
         assert isinstance(ctx, ContextCommand)
         if gef.config[f"{self._cmdline_}.use-capstone"] == True:


### PR DESCRIPTION
## Description/Motivation/Screenshots

hugsy/gef#1000 introduced a callback signature change for `on-write` hooks, which broke `capstone.py` (reported [on discord](https://discord.com/channels/705160148813086841/705160148813086843/1164321916404891729)). This PR fixes that

## How Has This Been Tested ?

"Tested" indicates that the PR works *and* the unit test (i.e. `make test`) run passes without issue.

*  [x] x86-32
*  [x] x86-64
*  [ ] ARM
*  [ ] AARCH64
*  [ ] MIPS
*  [ ] POWERPC
*  [ ] SPARC
*  [ ] RISC-V

## Checklist

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
*  [x] My code follows the code style of this project.
*  [x] My change includes a change to the documentation, if required.
*  [x] If my change adds new code,
   [adequate tests](https://hugsy.github.io/gef/testing) have been added.
*  [x] I have read and agree to the
   [CONTRIBUTING](https://github.com/hugsy/gef/blob/main/.github/CONTRIBUTING.md) document.
