### PR TITLE
Add support for BlackMagicProbe

### DIFF
--- a/archs/README.md
+++ b/archs/README.md
@@ -14,8 +14,8 @@ devices, power the target, and ultimately connect to the target device.
 
 #### Scan for devices
 
-```
-gef➤ gef-bmp-remote --scan /dev/ttyUSB1"
+```bash
+gef➤  gef-bmp-remote --scan /dev/ttyUSB1"
 [=] [remote] Executing 'monitor swdp_scan'
 Target voltage: 3.3V
 Available Targets:
@@ -31,7 +31,9 @@ numbered. Use the appropriate number to later `--attach`.
 If you are powering the device through the BMP, then make sure to add the `--power` arguments,
 otherwise the target may not be powered up when you attempt the scan.
 
-```
-gef-bmp-remote --file /path/to/binary.elf --target 1 /dev/ttyUSB1",
-gef-bmp-remote --file /path/to/binary.elf --target 1 --power /dev/ttyUSB1",
+If you want to keep power between scanning and attaching, then use `--keep-power`.
+
+```bash
+gef➤  gef-bmp-remote --file /path/to/binary.elf --attach 1 /dev/ttyUSB1",
+gef➤  gef-bmp-remote --file /path/to/binary.elf --attach 1 --power /dev/ttyUSB1",
 ```

--- a/archs/README.md
+++ b/archs/README.md
@@ -1,3 +1,37 @@
 ## Additional architectures for GEF
 
-Experiements for adding new architectures support for GEF
+Experiments for adding support for new architectures in GEF
+
+### Black Magic Probe
+
+The [Black Magic Probe](https://black-magic.org/) isa JTAG/SWD debugging that handles communicating
+with your device and exposes a _gdbserver_. This allows you to connect to it via GDB with the
+`remote` command. However, because this is exposed via a tty, GEF cannot handle it with its
+`gef-remote` command (which assumes a host:port connection). The
+[arm-blackmagicprobe.py](./arm-blackmagicprobe.py) script offers a way around this. It creates a
+custom ARM-derived `Architecture`, as well as the `gef-bmp-remote` command, which lets you scan for
+devices, power the target, and ultimately connect to the target device.
+
+#### Scan for devices
+
+```
+gef➤ gef-bmp-remote --scan /dev/ttyUSB1"
+[=] [remote] Executing 'monitor swdp_scan'
+Target voltage: 3.3V
+Available Targets:
+No. Att Driver
+ 1      Raspberry RP2040 M0+
+ 2      Raspberry RP2040 M0+
+ 3      Raspberry RP2040 Rescue (Attach to reset!)
+```
+
+This will connect to the BMP and use its scan feature to find valid targets connected. They will be
+numbered. Use the appropriate number to later `--attach`.
+
+If you are powering the device through the BMP, then make sure to add the `--power` arguments,
+otherwise the target may not be powered up when you attempt the scan.
+
+```
+gef-bmp-remote --file /path/to/binary.elf --target 1 /dev/ttyUSB1",
+gef-bmp-remote --file /path/to/binary.elf --target 1 --power /dev/ttyUSB1",
+```

--- a/archs/arm-blackmagicprobe.py
+++ b/archs/arm-blackmagicprobe.py
@@ -1,0 +1,185 @@
+"""
+ARM through the Black Magic Probe support for GEF
+
+To use, source this file *after* gef
+
+Author: Grazfather
+"""
+
+from typing import Optional
+
+import gdb
+
+
+class ARMBlackMagicProbe(ARM):
+    arch = "ARMBlackMagicProbe"
+    aliases = ("ARMBlackMagicProbe",)
+    all_registers = ("$r0", "$r1", "$r2", "$r3", "$r4", "$r5", "$r6",
+                     "$r7", "$r8", "$r9", "$r10", "$r11", "$r12", "$sp",
+                     "$lr", "$pc", "$xpsr")
+    flag_register = "$xpsr"
+    @staticmethod
+    def supports_gdb_arch(arch: str) -> Optional[bool]:
+        if "arm" in arch and arch.endswith("-m"):
+            return True
+        return None
+
+    @staticmethod
+    def maps():
+        yield from GefMemoryManager.parse_info_mem()
+
+
+@register
+class BMPRemoteCommand(GenericCommand):
+    """GDB `target remote` command on steroids. This command will use the remote procfs to create
+    a local copy of the execution environment, including the target binary and its libraries
+    in the local temporary directory (the value by default is in `gef.config.tempdir`). Additionally, it
+    will fetch all the /proc/PID/maps and loads all its information. If procfs is not available remotely, the command
+    will likely fail. You can however still use the limited command provided by GDB `target remote`."""
+
+    _cmdline_ = "gef-bmp-remote"
+    _syntax_  = f"{_cmdline_} [OPTIONS] TARGET"
+    _example_ = [f"{_cmdline_} --file /path/to/binary.elf --target 1 /dev/ttyUSB1",
+                 f"{_cmdline_} --file /path/to/binary.elf --target 1 --power /dev/ttyUSB1",
+                 f"{_cmdline_} --scan /dev/ttyUSB1",
+                 f"{_cmdline_} --tty /dev/ttyXYZ --file /path/to/binary.elf --target 1"]
+
+    def __init__(self) -> None:
+        super().__init__(prefix=False)
+        return
+
+    @parse_arguments({"tty": ""}, {"--file": "", "--target": "", "--power": False, "--scan": False})
+    def do_invoke(self, _: List[str], **kwargs: Any) -> None:
+        if gef.session.remote is not None:
+            err("You're already in a remote session. Close it first before opening a new one...")
+            return
+
+        # argument check
+        args : argparse.Namespace = kwargs["arguments"]
+        if not args.tty:
+            err("Missing parameters")
+            return
+
+        if args.scan:
+            with DisableContextOutputContext():
+                cmd = f"target extended-remote {args.tty}"
+                dbg(f"[remote] Executing '{cmd}'")
+                gdb.execute(cmd)
+                cmd = "monitor swdp_scan"
+                dbg(f"[remote] Executing '{cmd}'")
+                gdb.execute(cmd)
+                gdb.execute("disconnect")
+            return
+
+        # Try to establish the remote session, throw on error
+        # Set `.remote_initializing` to True here - `GefRemoteSessionManager` invokes code which
+        # calls `is_remote_debug` which checks if `remote_initializing` is True or `.remote` is None
+        # This prevents some spurious errors being thrown during startup
+        gef.session.remote_initializing = True
+        session = GefBMPRemoteSessionManager(args.tty, args.file, args.target, args.power)
+
+        dbg(f"[remote] initializing remote session with {session.target} under {session.root}")
+        if not session.connect() or not session.setup():
+            gef.session.remote = None
+            gef.session.remote_initializing = False
+            raise EnvironmentError("Failed to setup remote target")
+
+        gef.session.remote_initializing = False
+        gef.session.remote = session
+        reset_all_caches()
+        gdb.execute("context")
+        return
+
+
+class GefBMPRemoteSessionManager(GefRemoteSessionManager):
+    """Class for managing remote sessions with GEF. It will create a temporary environment
+    designed to clone the remote one."""
+    def __init__(self, tty: str="", file: str="", target: int=1, power: bool=False) -> None:
+        self.__tty = tty
+        self.__file = file
+        self.__target = target
+        self.__power = power
+        self.__local_root_fd = tempfile.TemporaryDirectory()
+        self.__local_root_path = pathlib.Path(self.__local_root_fd.name)
+
+    def __str__(self) -> str:
+        return f"BMPRemoteSessionManager(tty='{self.__tty}', file='{self.__file}', target={self.__target})"
+
+    @property
+    def root(self) -> pathlib.Path:
+        return self.__local_root_path.absolute()
+
+    @property
+    def target(self) -> str:
+        return f"{self.__tty} target {self.__target}"
+
+    def sync(self, src: str, dst: Optional[str] = None) -> bool:
+        pass
+
+    @property
+    def file(self) -> pathlib.Path:
+        return pathlib.Path(self.__file).expanduser()
+
+    @property
+    def maps(self) -> pathlib.Path:
+        if not self._maps:
+            self._maps = self.root / f"proc/{self.pid}/maps"
+        return self._maps
+
+    def connect(self) -> bool:
+        """Connect to remote target. If in extended mode, also attach to the given PID."""
+        # before anything, register our new hook to download files from the remote target
+        dbg(f"[remote] Installing new objfile handlers")
+        try:
+            gef_on_new_unhook(new_objfile_handler)
+        except SystemError:
+            # the default objfile handler might already have been removed, ignore failure
+            pass
+
+        gef_on_new_hook(self.remote_objfile_event_handler)
+
+        # then attempt to connect
+        try:
+            with DisableContextOutputContext():
+                cmd = f"file {self.__file}"
+                dbg(f"[remote] Executing '{cmd}'")
+                gdb.execute(cmd)
+                cmd = f"target extended-remote {self.__tty}"
+                dbg(f"[remote] Executing '{cmd}'")
+                gdb.execute(cmd)
+                if self.__power:
+                    cmd = f"monitor tpwr enable"
+                    dbg(f"[remote] Executing '{cmd}'")
+                    gdb.execute(cmd)
+                cmd = f"attach {self.__target or 1}"
+                dbg(f"[remote] Executing '{cmd}'")
+                gdb.execute(cmd)
+            return True
+        except Exception as e:
+            err(f"Failed to connect to {self.target}: {e}")
+
+        # a failure will trigger the cleanup, deleting our hook anyway
+        return False
+
+    def setup(self) -> bool:
+        # setup remote adequately depending on remote or qemu mode
+        dbg(f"Setting up as remote session")
+
+        # refresh gef to consider the binary
+        reset_all_caches()
+        gef.binary = Elf(self.file)
+        reset_architecture("ARMBlackMagicProbe")
+        return True
+
+    def remote_objfile_event_handler(self, evt: "gdb.NewObjFileEvent") -> None:
+        dbg(f"[remote] in remote_objfile_handler({evt.new_objfile.filename if evt else 'None'}))")
+        if not evt or not evt.new_objfile.filename:
+            return
+        if not evt.new_objfile.filename.startswith("target:") and not evt.new_objfile.filename.startswith("/"):
+            warn(f"[remote] skipping '{evt.new_objfile.filename}'")
+            return
+        if evt.new_objfile.filename.startswith("target:"):
+            src: str = evt.new_objfile.filename[len("target:"):]
+            if not self.sync(src):
+                raise FileNotFoundError(f"Failed to sync '{src}'")
+        return

--- a/archs/arm-blackmagicprobe.py
+++ b/archs/arm-blackmagicprobe.py
@@ -39,36 +39,33 @@ class BMPRemoteCommand(GenericCommand):
 
     _cmdline_ = "gef-bmp-remote"
     _syntax_  = f"{_cmdline_} [OPTIONS] TARGET"
-    _example_ = [f"{_cmdline_} --file /path/to/binary.elf --target 1 /dev/ttyUSB1",
+    _example_ = [
+                 f"{_cmdline_} --scan /dev/ttyUSB1"
+                 f"{_cmdline_} --scan /dev/ttyUSB1 --power"
+                 f"{_cmdline_} --scan /dev/ttyUSB1 --power --keep-power"
+                 f"{_cmdline_} --file /path/to/binary.elf --target 1 /dev/ttyUSB1",
                  f"{_cmdline_} --file /path/to/binary.elf --target 1 --power /dev/ttyUSB1",
-                 f"{_cmdline_} --scan /dev/ttyUSB1",
-                 f"{_cmdline_} --tty /dev/ttyXYZ --file /path/to/binary.elf --target 1"]
+                 ]
 
     def __init__(self) -> None:
         super().__init__(prefix=False)
         return
 
-    @parse_arguments({"tty": ""}, {"--file": "", "--target": "", "--power": False, "--scan": False})
+    @parse_arguments({"tty": ""}, {"--file": "", "--target": "", "--power": False,
+                                   "--keep-power": False, "--scan": False})
     def do_invoke(self, _: List[str], **kwargs: Any) -> None:
         if gef.session.remote is not None:
             err("You're already in a remote session. Close it first before opening a new one...")
             return
 
         # argument check
-        args : argparse.Namespace = kwargs["arguments"]
+        args: argparse.Namespace = kwargs["arguments"]
         if not args.tty:
             err("Missing parameters")
             return
 
-        if args.scan:
-            with DisableContextOutputContext():
-                cmd = f"target extended-remote {args.tty}"
-                dbg(f"[remote] Executing '{cmd}'")
-                gdb.execute(cmd)
-                cmd = "monitor swdp_scan"
-                dbg(f"[remote] Executing '{cmd}'")
-                gdb.execute(cmd)
-                gdb.execute("disconnect")
+        if not args.scan and not args.target:
+            err("Must provide target to attach to if not scanning")
             return
 
         # Try to establish the remote session, throw on error
@@ -76,10 +73,16 @@ class BMPRemoteCommand(GenericCommand):
         # calls `is_remote_debug` which checks if `remote_initializing` is True or `.remote` is None
         # This prevents some spurious errors being thrown during startup
         gef.session.remote_initializing = True
-        session = GefBMPRemoteSessionManager(args.tty, args.file, args.target, args.power)
+        session = GefBMPRemoteSessionManager(args.tty, args.file, args.target, args.scan, args.power)
 
         dbg(f"[remote] initializing remote session with {session.target} under {session.root}")
-        if not session.connect() or not session.setup():
+
+        # Connect can return false if it wants us to disconnect
+        if not session.connect():
+            gef.session.remote = None
+            gef.session.remote_initializing = False
+            return
+        if not session.setup():
             gef.session.remote = None
             gef.session.remote_initializing = False
             raise EnvironmentError("Failed to setup remote target")
@@ -94,16 +97,31 @@ class BMPRemoteCommand(GenericCommand):
 class GefBMPRemoteSessionManager(GefRemoteSessionManager):
     """Class for managing remote sessions with GEF. It will create a temporary environment
     designed to clone the remote one."""
-    def __init__(self, tty: str="", file: str="", target: int=1, power: bool=False) -> None:
+    def __init__(self, tty: str="", file: str="", target: int=1,
+                 scan: bool=False, power: bool=False, keep_power: bool=False) -> None:
         self.__tty = tty
         self.__file = file
         self.__target = target
+        self.__scan = scan
         self.__power = power
+        self.__keep_power = keep_power
         self.__local_root_fd = tempfile.TemporaryDirectory()
         self.__local_root_path = pathlib.Path(self.__local_root_fd.name)
 
     def __str__(self) -> str:
         return f"BMPRemoteSessionManager(tty='{self.__tty}', file='{self.__file}', target={self.__target})"
+
+    def close(self) -> None:
+        # TODO: Needed?
+        self.__local_root_fd.cleanup()
+        try:
+            gef_on_new_unhook(self.remote_objfile_event_handler)
+            gef_on_new_hook(new_objfile_handler)
+            if self.__power and not self.__keep_power:
+                self._power_off()
+        except Exception as e:
+            warn(f"Exception while restoring local context: {str(e)}")
+        return
 
     @property
     def root(self) -> pathlib.Path:
@@ -117,15 +135,17 @@ class GefBMPRemoteSessionManager(GefRemoteSessionManager):
         pass
 
     @property
-    def file(self) -> pathlib.Path:
-        return pathlib.Path(self.__file).expanduser()
+    def file(self) -> Optional[pathlib.Path]:
+        if self.__file:
+            return pathlib.Path(self.__file).expanduser()
+        return None
 
-    @property
-    def maps(self) -> pathlib.Path:
-        if not self._maps:
-            self._maps = self.root / f"proc/{self.pid}/maps"
-        return self._maps
-
+    # @property
+    # def maps(self) -> pathlib.Path:
+    #     if not self._maps:
+    #         self._maps = self.root / f"proc/{self.pid}/maps"
+    #     return self._maps
+    #
     def connect(self) -> bool:
         """Connect to remote target. If in extended mode, also attach to the given PID."""
         # before anything, register our new hook to download files from the remote target
@@ -138,22 +158,30 @@ class GefBMPRemoteSessionManager(GefRemoteSessionManager):
 
         gef_on_new_hook(self.remote_objfile_event_handler)
 
-        # then attempt to connect
+        # Connect
+        with DisableContextOutputContext():
+            self._gdb_execute(f"target extended-remote {self.__tty}")
+
+        # Optionally enable target-powering
+        if self.__power:
+            self._power_on()
+
+        # We must always scan, but with --scan we are done here.
+        self._gdb_execute("monitor swdp_scan")
+        if self.__scan:
+            # Returning false cleans up the session
+            self._gdb_execute("disconnect")
+            # Clear targets
+
+            # TODO: Suppress the error here
+            return False
+
         try:
+            reset_architecture("ARMBlackMagicProbe")
             with DisableContextOutputContext():
-                cmd = f"file {self.__file}"
-                dbg(f"[remote] Executing '{cmd}'")
-                gdb.execute(cmd)
-                cmd = f"target extended-remote {self.__tty}"
-                dbg(f"[remote] Executing '{cmd}'")
-                gdb.execute(cmd)
-                if self.__power:
-                    cmd = f"monitor tpwr enable"
-                    dbg(f"[remote] Executing '{cmd}'")
-                    gdb.execute(cmd)
-                cmd = f"attach {self.__target or 1}"
-                dbg(f"[remote] Executing '{cmd}'")
-                gdb.execute(cmd)
+                if self.file:
+                    self._gdb_execute(f"file {self.file}")
+                self._gdb_execute(f"attach {self.__target or 1}")
             return True
         except Exception as e:
             err(f"Failed to connect to {self.target}: {e}")
@@ -162,24 +190,35 @@ class GefBMPRemoteSessionManager(GefRemoteSessionManager):
         return False
 
     def setup(self) -> bool:
-        # setup remote adequately depending on remote or qemu mode
         dbg(f"Setting up as remote session")
 
         # refresh gef to consider the binary
         reset_all_caches()
-        gef.binary = Elf(self.file)
+        if self.file:
+            gef.binary = Elf(self.file)
+        # TODO: When should we set this?
         reset_architecture("ARMBlackMagicProbe")
         return True
 
-    def remote_objfile_event_handler(self, evt: "gdb.NewObjFileEvent") -> None:
-        dbg(f"[remote] in remote_objfile_handler({evt.new_objfile.filename if evt else 'None'}))")
-        if not evt or not evt.new_objfile.filename:
-            return
-        if not evt.new_objfile.filename.startswith("target:") and not evt.new_objfile.filename.startswith("/"):
-            warn(f"[remote] skipping '{evt.new_objfile.filename}'")
-            return
-        if evt.new_objfile.filename.startswith("target:"):
-            src: str = evt.new_objfile.filename[len("target:"):]
-            if not self.sync(src):
-                raise FileNotFoundError(f"Failed to sync '{src}'")
-        return
+    # def remote_objfile_event_handler(self, evt: "gdb.NewObjFileEvent") -> None:
+    #     dbg(f"[remote] in remote_objfile_handler({evt.new_objfile.filename if evt else 'None'}))")
+    #     if not evt or not evt.new_objfile.filename:
+    #         return
+    #     if not evt.new_objfile.filename.startswith("target:") and not evt.new_objfile.filename.startswith("/"):
+    #         warn(f"[remote] skipping '{evt.new_objfile.filename}'")
+    #         return
+    #     if evt.new_objfile.filename.startswith("target:"):
+    #         src: str = evt.new_objfile.filename[len("target:"):]
+    #         if not self.sync(src):
+    #             raise FileNotFoundError(f"Failed to sync '{src}'")
+    #     return
+
+    def _power_off(self):
+        self._gdb_execute("monitor tpwr disable")
+
+    def _power_on(self):
+        self._gdb_execute("monitor tpwr enable")
+
+    def _gdb_execute(self, cmd):
+        dbg(f"[remote] Executing '{cmd}'")
+        gdb.execute(cmd)

--- a/docs/archs/arm-blackmagicprobe.md
+++ b/docs/archs/arm-blackmagicprobe.md
@@ -1,0 +1,4 @@
+# ARMBlackMagicProbe
+
+The ARM BlackMagicProbe architecture is a special arcthtecture used with the `gef-bmp-remote`
+command. Please read the [documentation](../commands/gef-bmp-remote.md) for the command.

--- a/docs/archs/arm-blackmagicprobe.md
+++ b/docs/archs/arm-blackmagicprobe.md
@@ -1,4 +1,4 @@
-# ARMBlackMagicProbe
+## ARMBlackMagicProbe
 
 The ARM BlackMagicProbe architecture is a special arcthtecture used with the `gef-bmp-remote`
 command. Please read the [documentation](../commands/gef-bmp-remote.md) for the command.

--- a/docs/commands/gef-bmp-remote.md
+++ b/docs/commands/gef-bmp-remote.md
@@ -3,10 +3,10 @@
 The `gef-bmp-command` is used with the [`ARMBlackMagicProbe`](../../archs/arm-blackmagicprobe.py]
 architecture.
 
-The [Black Magic Probe](https://black-magic.org/) is a JTAG/SWD debugging that handles communicating
-with your device and exposes a _gdbserver_. This allows you to connect to it via GDB with the
-`remote` command. However, because this is exposed via a tty, GEF cannot handle it with its
-`gef-remote` command (which assumes a host:port connection). The
+The [Black Magic Probe](https://black-magic.org/) is a JTAG/SWD debugger that handles communicating
+with your device and exposes a _gdbserver_ for GDB to connect to. This allows you to connect to it
+via GDB with the `target extended-remote` command. However, because this is exposed via a tty, GEF
+cannot handle it with its `gef-remote` command (which assumes a _host:port_ connection). The
 [arm-blackmagicprobe.py](../../archs/arm-blackmagicprobe.py) script offers a way around this. It
 creates a custom ARM-derived `Architecture`, as well as the `gef-bmp-remote` command, which lets you
 scan for devices, power the target, and ultimately connect to the target device.

--- a/docs/commands/gef-bmp-remote.md
+++ b/docs/commands/gef-bmp-remote.md
@@ -1,18 +1,17 @@
-## Additional architectures for GEF
+# Command gef-bmp-remote
 
-Experiments for adding support for new architectures in GEF
+The `gef-bmp-command` is used with the [`ARMBlackMagicProbe`](../../archs/arm-blackmagicprobe.py]
+architecture.
 
-### Black Magic Probe
-
-The [Black Magic Probe](https://black-magic.org/) isa JTAG/SWD debugging that handles communicating
+The [Black Magic Probe](https://black-magic.org/) is a JTAG/SWD debugging that handles communicating
 with your device and exposes a _gdbserver_. This allows you to connect to it via GDB with the
 `remote` command. However, because this is exposed via a tty, GEF cannot handle it with its
 `gef-remote` command (which assumes a host:port connection). The
-[arm-blackmagicprobe.py](./arm-blackmagicprobe.py) script offers a way around this. It creates a
-custom ARM-derived `Architecture`, as well as the `gef-bmp-remote` command, which lets you scan for
-devices, power the target, and ultimately connect to the target device.
+[arm-blackmagicprobe.py](../../archs/arm-blackmagicprobe.py) script offers a way around this. It
+creates a custom ARM-derived `Architecture`, as well as the `gef-bmp-remote` command, which lets you
+scan for devices, power the target, and ultimately connect to the target device.
 
-#### Scan for devices
+# Scan for devices
 
 ```bash
 gef➤  gef-bmp-remote --scan /dev/ttyUSB1"

--- a/docs/commands/gef-bmp-remote.md
+++ b/docs/commands/gef-bmp-remote.md
@@ -1,4 +1,4 @@
-# Command gef-bmp-remote
+## Command gef-bmp-remote
 
 The `gef-bmp-command` is used with the [`ARMBlackMagicProbe`](../../archs/arm-blackmagicprobe.py]
 architecture.
@@ -11,7 +11,7 @@ cannot handle it with its `gef-remote` command (which assumes a _host:port_ conn
 creates a custom ARM-derived `Architecture`, as well as the `gef-bmp-remote` command, which lets you
 scan for devices, power the target, and ultimately connect to the target device.
 
-# Scan for devices
+### Scan for devices
 
 ```bash
 gef➤  gef-bmp-remote --scan /dev/ttyUSB1"


### PR DESCRIPTION
## Description/Motivation/Screenshots

This adds three things:

`gef-bmp-remote` command, to connect to a black magic probe. This is its own command because it connects to a tty instead of a host/port.

`GefBMPRemoteSessionManager`, which handles connecting and such.

`ARMBlackMagicProbe`, a new arch, which handles its own memory management and has different register names that e.g. openocd.

## How Has This Been Tested ?

Using my black magic probe to connect, attach, and successfully debug a target.

*  [ ] x86-32 (N/A)
*  [ ] x86-64 (N/A)
*  [x] ARM
*  [ ] AARCH64
*  [ ] MIPS (N/A)
*  [ ] POWERPC (N/A)
*  [ ] SPARC (N/A)
*  [ ] RISC-V (N/A)

## Checklist

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
*  [x] My code follows the code style of this project.
*  [ ] My change includes a change to the documentation, if required.
*  [ ] If my change adds new code,
   [adequate tests](https://hugsy.github.io/gef/testing) have been added.
*  [ ] I have read and agree to the
   [CONTRIBUTING](https://github.com/hugsy/gef/blob/main/.github/CONTRIBUTING.md) document.
