### PR TITLE
workflows: tests: Fix arg to check marks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,7 +77,7 @@ jobs:
 
     - name: Run Tests
       run: |
-        python${{ env.PY_VER }} -m pytest --forked -n ${{ env.NB_CPU }} -v -k "not benchmark" tests/
+        python${{ env.PY_VER }} -m pytest --forked -n ${{ env.NB_CPU }} -v -m "not benchmark" tests/
 
   standalone:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We used `-k "not benchmark"` which would filter out ANY test that contained the word 'benchmark'.

This change fixes that by using the `-m` argument to only filter on marks.

Same change as hugsy/gef#1064