### PR TITLE
fix path syscall-args search

### DIFF
--- a/scripts/syscall_args/__init__.py
+++ b/scripts/syscall_args/__init__.py
@@ -10,6 +10,8 @@ import pathlib
 import re
 from importlib.machinery import SourceFileLoader
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
+import inspect
+import os
 
 if TYPE_CHECKING:
     from .. import *
@@ -43,9 +45,11 @@ class SyscallArgsCommand(GenericCommand):
     def __init__(self) -> None:
         super().__init__(prefix=False, complete=gdb.COMPLETE_NONE)
         self.__path: Optional[pathlib.Path] = None
-        path = CURRENT_DIRECTORY / "syscall-tables"
-        self["path"] = (str(path.absolute()),
-                        "Path to store/load the syscall tables files")
+        caller_frame = inspect.stack()[0]
+        path = caller_frame.filename
+        path = os.path.join(os.path.dirname(os.path.abspath(path)), "syscall-tables")
+        self["path"] = (path, "Path to store/load the syscall tables files")
+
         return
 
     @property


### PR DESCRIPTION
## Description/Motivation/Screenshots

fix syscall-args path search

## How Has This Been Tested ?

"Tested" indicates that the PR works *and* the unit test (i.e. `make test`) run passes without issue.

*  [x] x86-32
*  [x] x86-64
*  [ ] ARM
*  [ ] AARCH64
*  [ ] MIPS
*  [ ] POWERPC
*  [ ] SPARC
*  [ ] RISC-V

## Checklist

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
*  [x] My code follows the code style of this project.
*  [x] My change includes a change to the documentation, if required.
*  [x] If my change adds new code,
   [adequate tests](https://hugsy.github.io/gef/testing) have been added.
*  [x] I have read and agree to the
   [CONTRIBUTING](https://github.com/hugsy/gef/blob/main/.github/CONTRIBUTING.md) document.
