### PR TITLE
check if layout exist before add: glibc, syscall

### DIFF
--- a/scripts/libc_function_args/__init__.py
+++ b/scripts/libc_function_args/__init__.py
@@ -143,13 +143,13 @@ class GlibcFunctionArguments:
 
         return function_name
 
-
-#
-# Register the context pane
-#
-register_external_context_pane(
-    GLIBC_FUNCTION_ARGS_CONTEXT_PANE_INDEX,
-    GlibcFunctionArguments.pane_content,
-    pane_title_function=GlibcFunctionArguments.pane_title,
-    condition=GlibcFunctionArguments.only_if_call,
-)
+if GLIBC_FUNCTION_ARGS_CONTEXT_PANE_INDEX not in gef.config["context.layout"]:
+    #
+    # Register the context pane
+    #
+    register_external_context_pane(
+        GLIBC_FUNCTION_ARGS_CONTEXT_PANE_INDEX,
+        GlibcFunctionArguments.pane_content,
+        pane_title_function=GlibcFunctionArguments.pane_title,
+        condition=GlibcFunctionArguments.only_if_call,
+    )

--- a/scripts/syscall_args/__init__.py
+++ b/scripts/syscall_args/__init__.py
@@ -131,9 +131,9 @@ def __syscall_args_pane_content() -> None:
 def __syscall_args_pane_title() -> str:
     return CONTEXT_PANE_DESCRIPTION
 
-
-#
-# Register a callback to `syscall-args` to automatically detect when a syscall is hit
-#
-register_external_context_pane(
-    CONTEXT_PANE_INDEX, __syscall_args_pane_content, pane_title_function=__syscall_args_pane_title, condition=__syscall_args_pane_condition)
+if CONTEXT_PANE_INDEX not in gef.config["context.layout"]:
+    #
+    # Register a callback to `syscall-args` to automatically detect when a syscall is hit
+    #
+    register_external_context_pane(
+        CONTEXT_PANE_INDEX, __syscall_args_pane_content, pane_title_function=__syscall_args_pane_title, condition=__syscall_args_pane_condition)


### PR DESCRIPTION
## Description/Motivation/Screenshots

check if layout exist before add: glibc, syscall

Currently, each time GEF is executed, the entries are added over and over again.

## How Has This Been Tested ?

"Tested" indicates that the PR works *and* the unit test (i.e. `make test`) run passes without issue.

*  [x] x86-32
*  [x] x86-64
*  [ ] ARM
*  [ ] AARCH64
*  [ ] MIPS
*  [ ] POWERPC
*  [ ] SPARC
*  [ ] RISC-V

## Checklist

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
*  [x] My code follows the code style of this project.
*  [x] My change includes a change to the documentation, if required.
*  [x] If my change adds new code,
   [adequate tests](https://hugsy.github.io/gef/testing) have been added.
*  [x] I have read and agree to the
   [CONTRIBUTING](https://github.com/hugsy/gef/blob/main/.github/CONTRIBUTING.md) document.
