### PR TITLE
64bit libc table generator had $r10 as 4th argument

### DIFF
--- a/scripts/libc_function_args/tables/generator.py
+++ b/scripts/libc_function_args/tables/generator.py
@@ -118,7 +118,7 @@ def generate_all_json_files() -> bool:
         # generate x86_64
         if libc_x64_funcdef_fpath in libc_funcdef_list and not generate_json_file(
             function_dict,
-            ["$rdi", "$rsi", "$rdx", "$r10", "$r8", "$r9"],
+            ["$rdi", "$rsi", "$rdx", "$rcx", "$r8", "$r9"],
             libc_x64_funcdef_fpath,
         ):
             logging.error(


### PR DESCRIPTION
## Description/Motivation/Screenshots

<!-- Describe technically what your patch does. -->
<!-- Why is this change required? What problem does it solve? -->
<!-- How does this patch make a better world? -->
<!-- How does this look? Add a screenshot if you can -->


## How Has This Been Tested ?

"Tested" indicates that the PR works *and* the unit test (i.e. `make test`) run passes without issue.

*  [ ] x86-32
*  [ ] x86-64
*  [ ] ARM
*  [ ] AARCH64
*  [ ] MIPS
*  [ ] POWERPC
*  [ ] SPARC
*  [ ] RISC-V

## Checklist

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
*  [ ] My code follows the code style of this project.
*  [ ] My change includes a change to the documentation, if required.
*  [ ] If my change adds new code,
   [adequate tests](https://hugsy.github.io/gef/testing) have been added.
*  [ ] I have read and agree to the
   [CONTRIBUTING](https://github.com/hugsy/gef/blob/main/.github/CONTRIBUTING.md) document.
