### PR TITLE
docs: Add instructions to bypass --break-system-packages error

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -38,6 +38,12 @@ wget -q -O- https://github.com/hugsy/gef/raw/main/scripts/gef-extras.sh | sh
 The script will download (via git) GEF-Extras, and set up your `~/.gef.rc` file so that you can
 start straight away.
 
+If you receive an error mentioning --break-system-packages, you can bypass it by running this command at your own risk:
+
+```bash
+wget -q -O- https://github.com/hugsy/gef/raw/main/scripts/gef-extras.sh | sed 's/\(pip install\)/\1 --break-system-packages/' | sh
+```
+
 Refer to the [installation page](install.md) for more installation methods.
 
 


### PR DESCRIPTION
## Description/Motivation/Screenshots

Updated the documentation to include a command that bypasses the --break-system-packages error. Users can now use the provided script at their own risk to install the necessary packages.

For less advanced Linux users this could be useful.

With this PR, I'm trying to prevent Github issues or queries on Discord regarding this error on install 
(This is a workaround).

<!-- Describe technically what your patch does. -->
<!-- Why is this change required? What problem does it solve? -->
<!-- How does this patch make a better world? -->
<!-- How does this look? Add a screenshot if you can -->


## How Has This Been Tested ?

"Tested" indicates that the PR works *and* the unit test (i.e. `make test`) run passes without issue.

*  [x] x86-32
*  [x] x86-64
*  [ ] ARM
*  [ ] AARCH64
*  [ ] MIPS
*  [ ] POWERPC
*  [ ] SPARC
*  [ ] RISC-V

## Checklist

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
*  [x] My code follows the code style of this project.
*  [x] My change includes a change to the documentation, if required.
*  [x] If my change adds new code,
   [adequate tests](https://hugsy.github.io/gef/testing) have been added.
*  [x] I have read and agree to the
   [CONTRIBUTING](https://github.com/hugsy/gef/blob/main/.github/CONTRIBUTING.md) document.
