### PR TITLE
Update generate-docs.yml

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.repository.fork == false
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install pre-requisite
         run: |
-          sudo apt install gdb-multiarch python3 python3-dev python3-wheel  -y
+          sudo apt update && sudo apt install gdb-multiarch python3 python3-dev python3-wheel  -y
           version=$(gdb -q -nx -ex 'pi print(f"{sys.version_info.major}.{sys.version_info.minor}", end="")' -ex quit)
           python${version} -m pip install --requirement docs/requirements.txt --upgrade
       - name: Build and publish the docs


### PR DESCRIPTION
This action fails due to missing `apt update` when preparing the env. This PR fixes that
It also updates GHA checkout to v4