### PR TITLE
WinDBG command r renamed to ri

### DIFF
--- a/scripts/windbg.py
+++ b/scripts/windbg.py
@@ -255,7 +255,7 @@ class WindbgXCommand(GenericCommand):
 class WindbgRCommand(GenericCommand):
     """WinDBG compatibility layer: r - register info"""
 
-    _cmdline_ = "r"
+    _cmdline_ = "ri"
     _syntax_ = f"{_cmdline_} [REGISTER[=VALUE]]"
 
     def print_regs(self, reg_list, width=16):


### PR DESCRIPTION
## Description/Motivation/Screenshots

<!-- Describe technically what your patch does. -->
The command `r` becomes `ri`.
<!-- Why is this change required? What problem does it solve? -->
`r` from WinDBG compatibility layer ("register info" command) in conflict with the `r` from GDB ("run" command).
<!-- How does this patch make a better world? -->
This very little change make gef-extras more convenient for people that have used GEF or GDB without gef for a long time.
Moreover, it makes more sense that the "run" command keeps the `r` alias; and "register info" takes `ri`.
<!-- How does this look? Add a screenshot if you can -->

The new `r` command:
```
gef➤  r
Starting program:  
Python Exception <class 'gdb.error'>: No executable file specified.
Use the "file" or "exec-file" command.
Error occurred in Python: No executable file specified.
Use the "file" or "exec-file" command.
gef➤  file ./hrpfinder
Reading symbols from ./hrpfinder...

This GDB supports auto-downloading debuginfo from the following URLs:
  <https://debuginfod.archlinux.org>
Debuginfod has been disabled.
To make this setting permanent, add 'set debuginfod enabled off' to .gdbinit.
(No debugging symbols found in ./hrpfinder)
gef➤  r
Starting program: /home/user_one/code/bech32hrpfinder/hrpfinder 
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/usr/lib/libthread_db.so.1".
1
1
83
6
1
5
1
[Inferior 1 (process 37931) exited normally]
gef➤  
```
the new `ri` command:
```
gef➤  ri
[*] No debugging session active
```
I didn't succeed to make the `ri` command working.

## How Has This Been Tested ?

"Tested" indicates that the PR works *and* the unit test (i.e. `make test`) run passes without issue.

*  [ ] x86-32
*  [ ] x86-64
*  [ ] ARM
*  [ ] AARCH64
*  [ ] MIPS
*  [ ] POWERPC
*  [ ] SPARC
*  [ ] RISC-V

## Checklist

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
*  [x] My code follows the code style of this project.
*  [ ] My change includes a change to the documentation, if required.
*  [ ] If my change adds new code,
   [adequate tests](https://hugsy.github.io/gef/testing) have been added.
*  [x] I have read and agree to the
   [CONTRIBUTING](https://github.com/hugsy/gef/blob/main/.github/CONTRIBUTING.md) document.
